### PR TITLE
feat: add support for some scopes used for clojure (via calva)

### DIFF
--- a/themes/Boxy Monokai.json
+++ b/themes/Boxy Monokai.json
@@ -51,7 +51,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#ae81ff"
 			}
@@ -101,7 +101,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#e6db74"
 			}

--- a/themes/Boxy Nova.json
+++ b/themes/Boxy Nova.json
@@ -51,7 +51,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#9a93e1"
 			}
@@ -101,7 +101,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#dada93"
 			}

--- a/themes/Boxy Ocean Light.json
+++ b/themes/Boxy Ocean Light.json
@@ -91,7 +91,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#b431b4"
 			}
@@ -141,7 +141,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#c98f1d"
 			}

--- a/themes/Boxy Ocean dimmed.json
+++ b/themes/Boxy Ocean dimmed.json
@@ -90,7 +90,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#c594c5"
 			}
@@ -140,7 +140,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#fac863"
 			}

--- a/themes/Boxy Ocean.json
+++ b/themes/Boxy Ocean.json
@@ -60,7 +60,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#c594c5"
 			}
@@ -110,7 +110,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#fac863"
 			}

--- a/themes/Boxy Solarized Dark.json
+++ b/themes/Boxy Solarized Dark.json
@@ -68,7 +68,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#6c71c4"
 			}
@@ -118,7 +118,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#b58900"
 			}

--- a/themes/Boxy Solarized Light.json
+++ b/themes/Boxy Solarized Light.json
@@ -52,7 +52,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#6c71c4"
 			}
@@ -102,7 +102,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#b58900"
 			}

--- a/themes/Boxy Tomorrow.json
+++ b/themes/Boxy Tomorrow.json
@@ -59,7 +59,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#b294bb"
 			}
@@ -109,7 +109,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#f0c674"
 			}

--- a/themes/Boxy Yesterday.json
+++ b/themes/Boxy Yesterday.json
@@ -52,7 +52,7 @@
 		},
 		{
 			"name": "Keyword, Storage",
-			"scope": "keyword, storage.type, storage.modifier",
+			"scope": "keyword, storage.type, storage.modifier, storage.control",
 			"settings": {
 				"foreground": "#8959a8"
 			}
@@ -102,7 +102,7 @@
 		},
 		{
 			"name": "Class, Support",
-			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter",
+			"scope": "entity.name.class, entity.name.type.class, support.type, support.class, support.other.namespace.use.php, meta.use.php, support.other.namespace.php, markup.changed.git_gutter, meta.metadata.simple",
 			"settings": {
 				"foreground": "#c99e00"
 			}


### PR DESCRIPTION
example file is from the clojure.string standard library, using the tomorrow theme.

Before:
<img width="667" alt="Screen Shot 2021-10-05 at 4 55 05 PM" src="https://user-images.githubusercontent.com/760204/136119536-aa825369-7b0c-41dc-8edf-f3a7e08257be.png">

After:
<img width="595" alt="Screen Shot 2021-10-05 at 4 54 50 PM" src="https://user-images.githubusercontent.com/760204/136119527-a347390f-3bd4-4200-91df-1a3779fcdcaa.png">

(brackets use my colors from #9)