### PR TITLE
Fix colorization of customized Python functions

### DIFF
--- a/themes/Boxy Monokai.json
+++ b/themes/Boxy Monokai.json
@@ -72,7 +72,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#66d9ef"
 			}

--- a/themes/Boxy Nova.json
+++ b/themes/Boxy Nova.json
@@ -72,7 +72,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#83afe5"
 			}

--- a/themes/Boxy Ocean Light.json
+++ b/themes/Boxy Ocean Light.json
@@ -114,7 +114,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#2673c0"
 			}

--- a/themes/Boxy Ocean dimmed.json
+++ b/themes/Boxy Ocean dimmed.json
@@ -111,7 +111,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#6699cc"
 			}

--- a/themes/Boxy Ocean.json
+++ b/themes/Boxy Ocean.json
@@ -81,7 +81,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#6699cc"
 			}

--- a/themes/Boxy Solarized Dark.json
+++ b/themes/Boxy Solarized Dark.json
@@ -89,7 +89,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#268bd2"
 			}

--- a/themes/Boxy Solarized Light.json
+++ b/themes/Boxy Solarized Light.json
@@ -73,7 +73,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#268bd2"
 			}

--- a/themes/Boxy Tomorrow.json
+++ b/themes/Boxy Tomorrow.json
@@ -80,7 +80,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#81a2be"
 			}

--- a/themes/Boxy Yesterday.json
+++ b/themes/Boxy Yesterday.json
@@ -73,7 +73,7 @@
 		},
 		{
 			"name": "Function, Special Method, Block Level",
-			"scope": "entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
+			"scope": "meta.function-call.generic.python, support.function.builtin.python, entity.name.type.class.templated, entity.name.type.class.generic, entity.name.type.namespace, entity.name.function, variable.function, support.function, keyword.other.special-method, meta.block-level",
 			"settings": {
 				"foreground": "#4271ae"
 			}


### PR DESCRIPTION
There is a problem of not colorizing non-built-in functions and class methods in Python. 
Only built-in functions are colorized now. 
I looked up the original Boxy Theme from Sublime Text and fixed this issue.